### PR TITLE
Fix npm start command

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "start-app": "cd app && npm start",
       "start-dev": "concurrently \"npm:start-api\" \"npm:start-app\" ",
       "start-swa": "swa start http://localhost:3000 --api-location http://localhost:7071",
-      "start": " npm run start-dev && npm run swa-up"
+      "start": " npm run start-dev & npm run start-swa"
     },
     "repository": {
       "type": "git",


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* `swa-up` is not defined in package.json. use `start-swa` instead.
* Also `&&` will wait success exit of previous command. so that we should use `&`

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
cd app && npm install && cd ..
cd api && npm install && cd ..
npm start
```

## What to Check
Verify that the following are valid
* Console log will show `[swa] Azure Static Web Apps emulator started at http://localhost:4280. Press CTRL+C to exit.`
* Open  http://localhost:4280 with browser and check api is working

## Other Information
<!-- Add any other helpful information that may be needed here. -->